### PR TITLE
Add file separator agnostic support to merge_comp_freqs.py

### DIFF
--- a/merge/merge_comp_freqs.py
+++ b/merge/merge_comp_freqs.py
@@ -56,12 +56,12 @@ def write_csv(stats):
 		print name + ',' + f + ',' + c
 	
 def parse_complexity(merged, row):
-	name = row[1][2:]
+	name = row[1][2:].replace("\\", "/")
 	complexity = row[4]
 	merged.record_detected(name, complexity)
 
 def parse_freqs(merged, row):
-	name = row[0]
+	name = row[0].replace("\\", "/")
 	freqs = row[1]
 	merged.extend_with(name, freqs)
 

--- a/merge/merge_comp_freqs_test.py
+++ b/merge/merge_comp_freqs_test.py
@@ -4,6 +4,7 @@ import merge_comp_freqs
 class MergeCompFreqsTest(unittest.TestCase):
 	FAKED_COMLEXITY_METRIC = 42
 	FAKED_MODULE = 'some/file/here.py'
+	FAKED_WINDOWS_MODULE = 'some\\file\\here.py'
 	FAKED_FREQS_METRIC = 26
 
 	def setUp(self):
@@ -19,6 +20,37 @@ class MergeCompFreqsTest(unittest.TestCase):
 		merge_comp_freqs.parse_freqs(self._merger, a_row)
 		updated = self._merger.sorted_result()
 		self.assertEqual(updated, [(self.FAKED_MODULE, (self.FAKED_FREQS_METRIC, self.FAKED_COMLEXITY_METRIC))])
+
+	def test_parses_freqs_row_windows(self):
+		a_row = [self.FAKED_WINDOWS_MODULE, self.FAKED_FREQS_METRIC]
+		merge_comp_freqs.parse_freqs(self._merger, a_row)
+		updated = self._merger.sorted_result()
+		self.assertEqual(updated, [(self.FAKED_MODULE, (self.FAKED_FREQS_METRIC, self.FAKED_COMLEXITY_METRIC))])
+
+	def test_parses_complexity_row(self):
+		fake_module = 'other/file/there.py'
+		fake_complexity_metric = 53
+		fake_freq_metric = 34
+		merger = merge_comp_freqs.Merged()
+		a_row = ['Python', "./" + fake_module, 0, 1, fake_complexity_metric]
+		merge_comp_freqs.parse_complexity(merger, a_row)
+		b_row = [fake_module, fake_freq_metric]
+		merge_comp_freqs.parse_freqs(merger, b_row)
+		updated = merger.sorted_result()
+		self.assertEqual(updated, [(fake_module, (fake_freq_metric, fake_complexity_metric))])
+
+	def test_parses_complexity_row_windows(self):
+		fake_module_windows = '.\\other\\file\\there.py'
+		fake_module = 'other/file/there.py'
+		fake_complexity_metric = 53
+		fake_freq_metric = 34
+		merger = merge_comp_freqs.Merged()
+		a_row = ['Python', fake_module_windows, 0, 1, fake_complexity_metric]
+		merge_comp_freqs.parse_complexity(merger, a_row)
+		b_row = [fake_module, fake_freq_metric]
+		merge_comp_freqs.parse_freqs(merger, b_row)
+		updated = merger.sorted_result()
+		self.assertEqual(updated, [(fake_module, (fake_freq_metric, fake_complexity_metric))])
 
 	def test_ignores_non_existent_change_records(self):
 		""" Since we're using historic data, some modules may no longer exist.


### PR DESCRIPTION
I added some calls to `replace` to replace back slashes `\` with forward slashes `/` in file names that are parsed.
