### PR TITLE
Fix indexing row during complexity parsing

### DIFF
--- a/merge/merge_comp_freqs.py
+++ b/merge/merge_comp_freqs.py
@@ -60,7 +60,7 @@ def as_os_aware_path(name):
 	return os.path.normpath(name)
 	
 def parse_complexity(merged, row):
-	name = as_os_aware_path(row[1][2:])
+	name = as_os_aware_path(row[1])
 	complexity = row[4]
 	merged.record_detected(name, complexity)
 


### PR DESCRIPTION
Indexing using [1][2:] caused the path to the filename
to be cut by two characters. As a result, the merge script
was failing.