### PR TITLE
Fix issue MacOS: csv_as_enclosure_json.py is not calculating weight #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,6 @@ Scripts used to post-process the results from Code Maat.
 These scripts are referenced from my upcoming book [Code as a Crime Scene](http://pragprog.com/book/atcrime/code-as-a-crime-scene).
 
 It's work in progress - none of the scripts is of production quality!
+
+The [master](https://github.com/adamtornhill/maat-scripts/tree/master) branch is compatible with Python 2.7
+while the [pyhton3](https://github.com/adamtornhill/maat-scripts/tree/python3) branch is compatible with Python 3.

--- a/transform/csv_as_enclosure_json.py
+++ b/transform/csv_as_enclosure_json.py
@@ -98,6 +98,8 @@ class StructuralElement(object):
 
 def parse_structural_element(csv_row):
 	name = csv_row[1]
+	if name.startswith('./'):
+		name = name[2:]
 	complexity = csv_row[4]
 	return StructuralElement(name, complexity)
 


### PR DESCRIPTION
## Summary

Fix issue MacOS: csv_as_enclosure_json.py is not calculating weight #10  and
document Python compatibility in README.md