### PR TITLE
fix: encoding errors are thrown for non UTF-8 files with special characters

### DIFF
--- a/miner/complexity_analysis.py
+++ b/miner/complexity_analysis.py
@@ -37,7 +37,7 @@ def as_csv(stats):
 
 
 def run(args):
-    with open(args.file, "r") as file_to_calc:
+    with open(file=args.file, mode="r", errors="replace") as file_to_calc:
         preprocessor = language_preprocessors.create_for(args.file)
         complexity_by_line = complexity_calculations.calculate_complexity_in(
             file_to_calc.read(), preprocessor)

--- a/miner/complexity_analysis_test.py
+++ b/miner/complexity_analysis_test.py
@@ -1,0 +1,38 @@
+import re
+import unittest
+import argparse
+import io
+import contextlib
+
+import complexity_analysis
+
+
+class ComplexityAnalysisTest(unittest.TestCase):
+    def test_complexity_analysis_should_process_non_utf8_encoded_files(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('file')
+
+        args = list(["./test-data/iso8859-1-encoded-test-file-with-umlauts.txt"])
+        args = parser.parse_args(args)
+
+        try:
+            buffer = io.StringIO()
+            with contextlib.redirect_stdout(buffer):
+                complexity_analysis.run(args)
+        except:
+            self.fail('complexity_analysis.run fails for iso-8859-1 encoded files')
+
+        self.assertContainsCsvData(buffer)
+
+    def assertContainsCsvData(self, buffer):
+        # Sample data:
+        # n, total, mean, sd, max
+        # 26, 40.0, 1.54, 1.22, 4.0
+        expected_regex = re.compile(
+            '^n, total, mean, sd, max$\n^[0-9]+,[0-9.]+,[0-9.]+,[0-9.]+,[0-9.]+$',
+            flags=re.MULTILINE)
+        self.assertRegex(buffer.getvalue(), expected_regex, 'complexity_analysis.run() should print csv data')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/miner/complexity_analysis_test.py
+++ b/miner/complexity_analysis_test.py
@@ -26,10 +26,10 @@ class ComplexityAnalysisTest(unittest.TestCase):
 
     def assertContainsCsvData(self, buffer):
         # Sample data:
-        # n, total, mean, sd, max
-        # 26, 40.0, 1.54, 1.22, 4.0
+        # n,total,mean,sd,max
+        # 26,40.0,1.54,1.22,4.0
         expected_regex = re.compile(
-            '^n, total, mean, sd, max$\n^[0-9]+,[0-9.]+,[0-9.]+,[0-9.]+,[0-9.]+$',
+            '^n,total,mean,sd,max$\n^[0-9]+,[0-9.]+,[0-9.]+,[0-9.]+,[0-9.]+$',
             flags=re.MULTILINE)
         self.assertRegex(buffer.getvalue(), expected_regex, 'complexity_analysis.run() should print csv data')
 

--- a/miner/git_complexity_trend_test.py
+++ b/miner/git_complexity_trend_test.py
@@ -48,7 +48,7 @@ class GitComplexityTrendTest(unittest.TestCase):
         parser.add_argument('--end')
         parser.add_argument('--file')
 
-        args = list(["--start", "f50795c2", "--end", "887dfea", "--file", "./test-data/iso8859-1-encoded-test-file-with-umlauts.txt"])
+        args = list(["--start", "f50795c2", "--end", "f39cd09", "--file", "./test-data/iso8859-1-encoded-test-file-with-umlauts.txt"])
         args = parser.parse_args(args)
 
         buffer = io.StringIO()

--- a/miner/git_complexity_trend_test.py
+++ b/miner/git_complexity_trend_test.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 import argparse
 import io
@@ -40,6 +41,34 @@ class GitComplexityTrendTest(unittest.TestCase):
                     '']
         actual = buffer.getvalue().split("\n")
         self.assertEqual(expected, actual)
+
+    def test_git_complexity_trend_should_process_non_utf8_encoded_files(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--start')
+        parser.add_argument('--end')
+        parser.add_argument('--file')
+
+        args = list(["--start", "f50795c2", "--end", "887dfea", "--file", "./test-data/iso8859-1-encoded-test-file-with-umlauts.txt"])
+        args = parser.parse_args(args)
+
+        buffer = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(buffer):
+                git_complexity_trend.run(args)
+        except:
+            self.fail('git_complexity_trend.run fails for iso-8859-1 encoded files')
+
+        self.assertContainsCsvData(buffer)
+
+    def assertContainsCsvData(self, buffer):
+        # Sample data:
+        # rev,n,total,mean,sd
+        # 7aef5de,52,102.0,1.96,1.13
+        # 839c8d1,52,101.0,1.94,1.12
+        expected_regex = re.compile(
+            '^rev,n,total,mean,sd$\n^[0-9a-f]{7},[0-9]+,[0-9.]+,[0-9.]+,[0-9.]+$',
+            flags=re.MULTILINE)
+        self.assertRegex(buffer.getvalue(), expected_regex, 'git_complexity_trend.run() should print csv data')
 
 
 if __name__ == '__main__':

--- a/miner/git_interactions.py
+++ b/miner/git_interactions.py
@@ -13,7 +13,7 @@ def _run_git_cmd(git_arguments):
         encoding = sys.stdout.encoding
 
     stdout_bytes = subprocess.Popen(git_arguments, stdout=subprocess.PIPE).communicate()[0]
-    stdout = stdout_bytes.decode(encoding)
+    stdout = stdout_bytes.decode(encoding=encoding, errors="replace")
     return stdout
 
 

--- a/miner/test-data/iso8859-1-encoded-test-file-with-umlauts.txt
+++ b/miner/test-data/iso8859-1-encoded-test-file-with-umlauts.txt
@@ -1,0 +1,3 @@
+This test file contains special characters for which the representation differs in UTF-8 and ISO-8859-1.
+
+ÄÖÜäöüß


### PR DESCRIPTION
## Note

The test `test_git_complexity_trend_should_process_non_utf8_encoded_files` will fail, if the git commit hash changes for commit [f39cd09](https://github.com/wonderbird/maat-scripts/commit/f39cd099fd5daa4408cf00c02ddc330285a20ea6) (test: complexity_trend for iso-8859-1 encoded files must not throw error), because that commit hash is hard coded into the test. If that happens, I would fix the issue later.

## Summary

While analyzing files using ISO-8859-1 encoding, I encountered errors thrown by methods processing the files.

## Details

This PR fixes some of the read / parse functions so that no errors are thrown.

At the moment the code is configured to replace special characters in non unicode files by '?'. In the analysis functions to measure complexity and complexity trend. This shouldn't have any impact on the results.
